### PR TITLE
Add user-based visits and auth support

### DIFF
--- a/DATABASE_SCHEMA.md
+++ b/DATABASE_SCHEMA.md
@@ -1,6 +1,10 @@
 # Database Schema
 
-## tables
+This project stores its data in a Postgres database managed by Supabase.
+The schema consists of the following tables and helper SQL functions used by the
+application loaders.
+
+## Tables
 
 ### categories
 
@@ -23,4 +27,26 @@
 
 ### visits
 
+- `user_id` uuid references `auth.users.id`
 - `place_id` integer references `places.id`
+- `visited_at` timestamptz default `now()`
+- primary key (`user_id`, `place_id`)
+- row level security enabled with policy `auth.uid() = user_id`
+
+## Functions
+
+### `prefecture_progress(p_user_id uuid, p_category int)`
+
+Returns progress information for each prefecture. When `p_category` is `NULL`
+all categories are aggregated. The result contains `id`, `name`, `visited`
+(count of visits), and `total` (number of places).
+
+### `places_with_visit(p_user_id uuid, p_prefecture int, p_category int)`
+
+Returns all places for the specified prefecture and optional category together
+with a boolean `visited` flag.
+
+### `places_by_category(p_user_id uuid, p_category int)`
+
+Returns all places for the provided category across all prefectures with a
+`visited` flag.

--- a/app/api/hooks.ts
+++ b/app/api/hooks.ts
@@ -2,11 +2,12 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { supabase } from './supabaseClient';
 import { getCurrentUser } from './supabaseClient';
 
+export function useCurrentUser() {
+  return useQuery({ queryKey: ['user'], queryFn: getCurrentUser });
+}
+
 export function usePrefectures() {
-  const { data: userId } = useQuery({
-    queryKey: ['user'],
-    queryFn: getCurrentUser,
-  });
+  const { data: userId } = useCurrentUser();
   return useQuery({
     queryKey: ['prefectures', userId],
     queryFn: () => supabase.rpc('prefecture_progress', { p_user_id: userId }),
@@ -15,10 +16,7 @@ export function usePrefectures() {
 }
 
 export function useToggleVisit() {
-  const { data: userId } = useQuery({
-    queryKey: ['user'],
-    queryFn: getCurrentUser,
-  });
+  const { data: userId } = useCurrentUser();
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async ({

--- a/app/api/supabase.server.ts
+++ b/app/api/supabase.server.ts
@@ -1,238 +1,96 @@
 import { createClient } from '@supabase/supabase-js';
 
-// 開発用のデフォルト値を設定
-const supabaseUrl = process.env.SUPABASE_URL || 'https://localhost:3000';
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY || 'demo-key';
+const supabaseUrl = process.env.SUPABASE_URL || '';
+const supabaseAnonKey = process.env.SUPABASE_ANON_KEY || '';
 
-// 実際のSupabaseプロジェクトがない場合は、モックデータを使用
-const hasValidSupabaseConfig =
-  process.env.SUPABASE_URL &&
-  process.env.SUPABASE_ANON_KEY &&
-  process.env.SUPABASE_URL.startsWith('https://') &&
-  process.env.SUPABASE_URL !== 'your_supabase_url_here';
+export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: { persistSession: false },
+});
 
-// SSR: pull keys from process.env (Vercel Edge uses the same)
-export const supabase = hasValidSupabaseConfig
-  ? createClient(
-      supabaseUrl,
-      supabaseAnonKey,
-      { auth: { persistSession: false } } // no localStorage on server
-    )
-  : null;
-
-// モックデータの関数
-export const categories = [
-  { id: 1, key: 'station', slug: 'stations', name: '主要駅' },
-  { id: 2, key: 'temple', slug: 'temples', name: '有名寺院' },
-  { id: 3, key: 'sight', slug: 'sightseeing', name: '観光地' },
-  { id: 4, key: 'park', slug: 'parks', name: '公園' },
-  { id: 5, key: 'museum', slug: 'museums', name: '博物館' },
-  { id: 6, key: 'castle', slug: 'castles', name: '城跡' },
-  { id: 7, key: 'hotSpring', slug: 'hot-springs', name: '温泉' },
-  { id: 8, key: 'view', slug: 'viewpoints', name: '展望台' },
-] as const;
-
-export type Category = (typeof categories)[number];
-export type CategoryId = Category['id'];
-export type CategorySlug = Category['slug'];
-export type CategoryKey = Category['key'];
-
-export async function fetchPlacesByCategory(categoryId: CategoryId) {
-  if (supabase) {
-    const { data } = await supabase.rpc('places_by_category', {
-      p_category: categoryId,
-    });
-    return data ?? [];
-  }
-  return getMockData.places_by_category(categoryId);
+export async function getUser(request: Request): Promise<string | null> {
+  const token = request.headers.get('authorization')?.replace('Bearer ', '');
+  if (!token) return null;
+  const { data } = await supabase.auth.getUser(token);
+  return data.user?.id ?? null;
 }
 
-const prefectureNames = [
-  '北海道',
-  '青森県',
-  '岩手県',
-  '宮城県',
-  '秋田県',
-  '山形県',
-  '福島県',
-  '茨城県',
-  '栃木県',
-  '群馬県',
-  '埼玉県',
-  '千葉県',
-  '東京都',
-  '神奈川県',
-  '新潟県',
-  '富山県',
-  '石川県',
-  '福井県',
-  '山梨県',
-  '長野県',
-  '岐阜県',
-  '静岡県',
-  '愛知県',
-  '三重県',
-  '滋賀県',
-  '京都府',
-  '大阪府',
-  '兵庫県',
-  '奈良県',
-  '和歌山県',
-  '鳥取県',
-  '島根県',
-  '岡山県',
-  '広島県',
-  '山口県',
-  '徳島県',
-  '香川県',
-  '愛媛県',
-  '高知県',
-  '福岡県',
-  '佐賀県',
-  '長崎県',
-  '熊本県',
-  '大分県',
-  '宮崎県',
-  '鹿児島県',
-  '沖縄県',
-];
+export interface Category {
+  id: number;
+  key: string;
+  slug: string;
+  name: string;
+}
+export type CategoryId = Category['id'];
+export type CategorySlug = Category['slug'];
 
-const generatePlaces = (prefecture_id: number) => {
-  const prefectureName = prefectureNames[prefecture_id - 1] || '不明';
-  return [
-    {
-      id: prefecture_id * 100 + 1,
-      name: `${prefectureName}の主要駅`,
-      visited: false,
-      prefecture_id,
-      category_id: 1,
-    },
-    {
-      id: prefecture_id * 100 + 2,
-      name: `${prefectureName}の有名寺院`,
-      visited: true,
-      prefecture_id,
-      category_id: 2,
-    },
-    {
-      id: prefecture_id * 100 + 3,
-      name: `${prefectureName}の観光地`,
-      visited: false,
-      prefecture_id,
-      category_id: 3,
-    },
-    {
-      id: prefecture_id * 100 + 4,
-      name: `${prefectureName}の公園`,
-      visited: true,
-      prefecture_id,
-      category_id: 4,
-    },
-    {
-      id: prefecture_id * 100 + 5,
-      name: `${prefectureName}の博物館`,
-      visited: false,
-      prefecture_id,
-      category_id: 5,
-    },
-    {
-      id: prefecture_id * 100 + 6,
-      name: `${prefectureName}の城跡`,
-      visited: true,
-      prefecture_id,
-      category_id: 6,
-    },
-    {
-      id: prefecture_id * 100 + 7,
-      name: `${prefectureName}の温泉`,
-      visited: false,
-      prefecture_id,
-      category_id: 7,
-    },
-    {
-      id: prefecture_id * 100 + 8,
-      name: `${prefectureName}の展望台`,
-      visited: false,
-      prefecture_id,
-      category_id: 8,
-    },
-  ];
-};
+export interface PrefectureProgressRow {
+  id: number;
+  name: string;
+  visited: number;
+  total: number;
+}
 
-export const getMockData = {
-  prefecture_progress: (category_id?: number) => {
-    if (!category_id) {
-      return [
-        { id: 1, name: '北海道', visited: 15, total: 25 },
-        { id: 2, name: '青森県', visited: 3, total: 8 },
-        { id: 3, name: '岩手県', visited: 2, total: 7 },
-        { id: 4, name: '宮城県', visited: 4, total: 9 },
-        { id: 5, name: '秋田県', visited: 1, total: 6 },
-        { id: 6, name: '山形県', visited: 2, total: 7 },
-        { id: 7, name: '福島県', visited: 3, total: 8 },
-        { id: 8, name: '茨城県', visited: 2, total: 6 },
-        { id: 9, name: '栃木県', visited: 3, total: 7 },
-        { id: 10, name: '群馬県', visited: 2, total: 6 },
-        { id: 11, name: '埼玉県', visited: 5, total: 10 },
-        { id: 12, name: '千葉県', visited: 6, total: 11 },
-        { id: 13, name: '東京都', visited: 12, total: 20 },
-        { id: 14, name: '神奈川県', visited: 8, total: 15 },
-        { id: 15, name: '新潟県', visited: 3, total: 8 },
-        { id: 16, name: '富山県', visited: 2, total: 5 },
-        { id: 17, name: '石川県', visited: 3, total: 6 },
-        { id: 18, name: '福井県', visited: 1, total: 4 },
-        { id: 19, name: '山梨県', visited: 2, total: 5 },
-        { id: 20, name: '長野県', visited: 4, total: 9 },
-        { id: 21, name: '岐阜県', visited: 2, total: 6 },
-        { id: 22, name: '静岡県', visited: 5, total: 9 },
-        { id: 23, name: '愛知県', visited: 7, total: 12 },
-        { id: 24, name: '三重県', visited: 3, total: 7 },
-        { id: 25, name: '滋賀県', visited: 2, total: 5 },
-        { id: 26, name: '京都府', visited: 8, total: 14 },
-        { id: 27, name: '大阪府', visited: 9, total: 16 },
-        { id: 28, name: '兵庫県', visited: 6, total: 11 },
-        { id: 29, name: '奈良県', visited: 4, total: 8 },
-        { id: 30, name: '和歌山県', visited: 2, total: 6 },
-        { id: 31, name: '鳥取県', visited: 1, total: 4 },
-        { id: 32, name: '島根県', visited: 2, total: 5 },
-        { id: 33, name: '岡山県', visited: 3, total: 7 },
-        { id: 34, name: '広島県', visited: 4, total: 8 },
-        { id: 35, name: '山口県', visited: 2, total: 6 },
-        { id: 36, name: '徳島県', visited: 1, total: 4 },
-        { id: 37, name: '香川県', visited: 2, total: 5 },
-        { id: 38, name: '愛媛県', visited: 3, total: 6 },
-        { id: 39, name: '高知県', visited: 2, total: 5 },
-        { id: 40, name: '福岡県', visited: 6, total: 11 },
-        { id: 41, name: '佐賀県', visited: 1, total: 4 },
-        { id: 42, name: '長崎県', visited: 3, total: 7 },
-        { id: 43, name: '熊本県', visited: 4, total: 8 },
-        { id: 44, name: '大分県', visited: 2, total: 6 },
-        { id: 45, name: '宮崎県', visited: 2, total: 5 },
-        { id: 46, name: '鹿児島県', visited: 3, total: 7 },
-        { id: 47, name: '沖縄県', visited: 4, total: 9 },
-      ];
-    }
+export interface PlaceWithVisit {
+  id: number;
+  name: string;
+  visited: boolean;
+  prefecture_id?: number;
+}
 
-    return prefectureNames.map((name, index) => {
-      const id = index + 1;
-      const places = generatePlaces(id).filter(
-        p => p.category_id === category_id
-      );
-      const visited = places.filter(p => p.visited).length;
-      return { id, name, visited, total: places.length };
-    });
-  },
+let cachedCategories: Category[] | null = null;
 
-  places_with_visit: (prefecture_id: number, category_id?: number) => {
-    const places = generatePlaces(prefecture_id);
-    return category_id
-      ? places.filter(p => p.category_id === category_id)
-      : places;
-  },
+export async function fetchCategories(): Promise<Category[]> {
+  if (cachedCategories) return cachedCategories;
+  const { data, error } = await supabase
+    .from('categories')
+    .select('*')
+    .order('id');
+  if (error) throw error;
+  cachedCategories = data ?? [];
+  return cachedCategories;
+}
 
-  places_by_category: (category_id: number) => {
-    return prefectureNames.flatMap((_, index) =>
-      generatePlaces(index + 1).filter(p => p.category_id === category_id)
-    );
-  },
-};
+export async function fetchCategoryBySlug(
+  slug: CategorySlug
+): Promise<Category | null> {
+  const categories = await fetchCategories();
+  return categories.find(c => c.slug === slug) ?? null;
+}
+
+export async function fetchPrefectureProgress(
+  userId: string | null,
+  categoryId?: number
+): Promise<PrefectureProgressRow[]> {
+  const { data, error } = await supabase.rpc('prefecture_progress', {
+    p_user_id: userId,
+    p_category: categoryId ?? null,
+  });
+  if (error) throw error;
+  return data ?? [];
+}
+
+export async function fetchPlacesWithVisit(
+  userId: string | null,
+  prefectureId: number,
+  categoryId?: number
+): Promise<PlaceWithVisit[]> {
+  const { data, error } = await supabase.rpc('places_with_visit', {
+    p_user_id: userId,
+    p_prefecture: prefectureId,
+    p_category: categoryId ?? null,
+  });
+  if (error) throw error;
+  return data ?? [];
+}
+
+export async function fetchPlacesByCategory(
+  userId: string | null,
+  categoryId: number
+): Promise<PlaceWithVisit[]> {
+  const { data, error } = await supabase.rpc('places_by_category', {
+    p_user_id: userId,
+    p_category: categoryId,
+  });
+  if (error) throw error;
+  return data ?? [];
+}

--- a/app/api/supabaseClient.ts
+++ b/app/api/supabaseClient.ts
@@ -1,0 +1,13 @@
+import { createBrowserClient } from '@supabase/ssr';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || '';
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || '';
+
+export const supabase = createBrowserClient(supabaseUrl, supabaseAnonKey, {
+  auth: { persistSession: true },
+});
+
+export async function getCurrentUser() {
+  const { data } = await supabase.auth.getUser();
+  return data.user?.id ?? null;
+}

--- a/app/api/supabaseClient.ts
+++ b/app/api/supabaseClient.ts
@@ -11,3 +11,7 @@ export async function getCurrentUser() {
   const { data } = await supabase.auth.getUser();
   return data.user?.id ?? null;
 }
+
+export async function signOut() {
+  await supabase.auth.signOut();
+}

--- a/app/components/PrefectureListSidebar.tsx
+++ b/app/components/PrefectureListSidebar.tsx
@@ -1,3 +1,7 @@
+import { Link } from 'react-router';
+
+import { useCurrentUser } from '~/api/hooks';
+import { signOut } from '~/api/supabaseClient';
 import {
   Accordion,
   AccordionContent,
@@ -39,6 +43,7 @@ const PrefectureListSidebar: React.FC<PrefectureListSidebarProps> = ({
   onPrefectureSelect,
   selectedPrefectureId,
 }) => {
+  const { data: userId } = useCurrentUser();
   const getProgressColor = (progress: number) => {
     if (progress === 0) return 'bg-gray-200';
     if (progress < 0.3) return 'bg-yellow-500';
@@ -89,6 +94,20 @@ const PrefectureListSidebar: React.FC<PrefectureListSidebarProps> = ({
       <div className='border-border bg-card border-b p-4'>
         <h1 className='text-foreground text-lg font-bold'>Place Tracker</h1>
         <p className='text-muted-foreground mt-1 text-xs'>地域別一覧</p>
+        <div className='mt-2'>
+          {userId ? (
+            <button
+              onClick={() => signOut()}
+              className='text-primary text-xs underline'
+            >
+              Logout
+            </button>
+          ) : (
+            <Link to='/login' className='text-primary text-xs underline'>
+              Login
+            </Link>
+          )}
+        </div>
       </div>
 
       {/* 地域別アコーディオンリスト */}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useEffect } from 'react';
 import {
   isRouteErrorResponse,
   Links,
@@ -7,6 +8,8 @@ import {
   Scripts,
   ScrollRestoration,
 } from 'react-router';
+
+import { supabase } from '~/api/supabaseClient';
 
 import type { Route } from './+types/root';
 import './app.css';
@@ -50,6 +53,14 @@ export function Layout({ children }: { children: React.ReactNode }) {
 }
 
 export default function App() {
+  useEffect(() => {
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange(() => {
+      queryClient.invalidateQueries({ queryKey: ['user'] });
+    });
+    return () => subscription.unsubscribe();
+  }, []);
   return (
     <QueryClientProvider client={queryClient}>
       <Outlet />

--- a/app/routes/attributes.$slug.tsx
+++ b/app/routes/attributes.$slug.tsx
@@ -4,13 +4,16 @@ import { resolve } from 'path';
 import type { FeatureCollection } from 'geojson';
 import { useLoaderData } from 'react-router';
 
-import { supabase, getMockData, categories } from '~/api/supabase.server';
-import type { CategorySlug } from '~/api/supabase.server';
+import {
+  fetchPrefectureProgress,
+  fetchCategoryBySlug,
+  getUser,
+  type CategorySlug,
+} from '~/api/supabase.server';
 import PrefectureListSidebar from '~/components/PrefectureListSidebar';
 import PrefectureMap from '~/components/PrefectureMap';
 import {
   mergeProgressWithGeoJSON,
-  createMockFeatures,
   type PrefectureProgress,
 } from '~/lib/prefectures';
 
@@ -28,19 +31,16 @@ export function meta({ data }: Route.MetaArgs) {
   ];
 }
 
-export async function loader({ params }: Route.LoaderArgs) {
+export async function loader({ request, params }: Route.LoaderArgs) {
+  const userId = await getUser(request);
   const slug = params.slug as CategorySlug | undefined;
-  const category = slug ? categories.find(c => c.slug === slug) : undefined;
+  const category = slug ? await fetchCategoryBySlug(slug) : undefined;
   if (!category) {
     throw new Response('Category not found', { status: 404 });
   }
   try {
     // ❶ progress 集計
-    const progress = supabase
-      ? ((
-          await supabase.rpc('prefecture_progress', { p_category: category.id })
-        ).data ?? getMockData.prefecture_progress(category.id))
-      : getMockData.prefecture_progress(category.id);
+    const progress = await fetchPrefectureProgress(userId, category.id);
 
     // ❂ GeoJSON ファイル (public/) を読み込む
     const geoJsonPath = resolve('public/japan-prefectures.geojson');
@@ -54,11 +54,7 @@ export async function loader({ params }: Route.LoaderArgs) {
 
     return { features, category };
   } catch {
-    // Fallback: モックデータのみ使用
-    const progress = getMockData.prefecture_progress(category.id);
-    const features = createMockFeatures(progress as PrefectureProgress[]);
-
-    return { features, category };
+    throw new Response('Failed to load prefecture data', { status: 500 });
   }
 }
 

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -1,0 +1,13 @@
+import { Auth } from '@supabase/auth-ui-react';
+
+import { supabase } from '~/api/supabaseClient';
+
+export const meta = () => [{ title: 'Login - Place Tracker' }];
+
+export default function Login() {
+  return (
+    <main className='flex h-screen items-center justify-center'>
+      <Auth supabaseClient={supabase} />
+    </main>
+  );
+}

--- a/app/routes/prefecture-data.tsx
+++ b/app/routes/prefecture-data.tsx
@@ -1,77 +1,61 @@
-import { supabase, getMockData, categories } from '~/api/supabase.server';
-import type { CategorySlug } from '~/api/supabase.server';
+import {
+  fetchPlacesWithVisit,
+  fetchPrefectureProgress,
+  fetchCategoryBySlug,
+  getUser,
+  supabase,
+  type CategorySlug,
+} from '~/api/supabase.server';
 
 import type { Route } from './+types/prefecture-data';
 
 // ヘルパー関数: 場所データと進捗データの取得
 async function fetchPlacesAndProgress(
+  userId: string | null,
   prefectureId: number,
   categoryId?: number
 ) {
-  try {
-    if (supabase) {
-      const { data, error } = await supabase.rpc('places_with_visit', {
-        p_prefecture: prefectureId,
-        p_category: categoryId ?? null,
-      });
-      if (error) throw new Error(JSON.stringify(error));
-
-      return {
-        places: data,
-        prefecture: getMockData
-          .prefecture_progress(categoryId)
-          .find(p => p.id === prefectureId),
-      };
-    }
-    // Supabaseが利用不可の場合、モックデータを使用
-    return {
-      places: getMockData.places_with_visit(prefectureId, categoryId),
-      prefecture: getMockData
-        .prefecture_progress(categoryId)
-        .find(p => p.id === prefectureId),
-    };
-  } catch {
-    // エラー時のフォールバック: モックデータを使用
-    return {
-      places: getMockData.places_with_visit(prefectureId, categoryId),
-      prefecture: getMockData
-        .prefecture_progress(categoryId)
-        .find(p => p.id === prefectureId),
-    };
-  }
+  const places = await fetchPlacesWithVisit(userId, prefectureId, categoryId);
+  const progress = await fetchPrefectureProgress(userId, categoryId);
+  return {
+    places,
+    prefecture: progress.find(p => p.id === prefectureId),
+  };
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
+  const userId = await getUser(request);
   const url = new URL(request.url);
   const prefectureId = Number(url.searchParams.get('id'));
   const categorySlug = url.searchParams.get('category') as CategorySlug | null;
   const category = categorySlug
-    ? categories.find(c => c.slug === categorySlug)
+    ? await fetchCategoryBySlug(categorySlug)
     : undefined;
 
   if (!prefectureId) {
     throw new Response('Prefecture ID is required', { status: 400 });
   }
 
-  return await fetchPlacesAndProgress(prefectureId, category?.id);
+  return await fetchPlacesAndProgress(userId, prefectureId, category?.id);
 }
 
 export async function action({ request }: Route.ActionArgs) {
+  const userId = await getUser(request);
   const formData = await request.formData();
   const placeId = formData.get('placeId') as string;
   const visited = formData.get('visited') === 'true';
 
   try {
-    if (supabase) {
-      if (visited) {
-        await supabase.from('visits').delete().eq('place_id', placeId);
-      } else {
-        await supabase.from('visits').insert({ place_id: placeId });
-      }
+    if (visited) {
+      await supabase
+        .from('visits')
+        .delete()
+        .eq('user_id', userId)
+        .eq('place_id', placeId);
     } else {
-      console.log(
-        `Mock: ${visited ? 'Removing' : 'Adding'} visit for place ${placeId}`
-      );
+      await supabase
+        .from('visits')
+        .insert({ user_id: userId, place_id: placeId });
     }
     return { ok: true };
   } catch (err) {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@react-router/serve": "^7.5.3",
     "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.50.3",
+    "@supabase/auth-ui-react": "^0.3.4",
     "@tanstack/react-query": "^5.81.5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@react-router/fs-routes": "^7.6.3",
     "@react-router/node": "^7.5.3",
     "@react-router/serve": "^7.5.3",
+    "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.50.3",
     "@tanstack/react-query": "^5.81.5",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@react-router/serve':
         specifier: ^7.5.3
         version: 7.6.3(react-router@7.6.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)
+      '@supabase/ssr':
+        specifier: ^0.6.1
+        version: 0.6.1(@supabase/supabase-js@2.50.3)
       '@supabase/supabase-js':
         specifier: ^2.50.3
         version: 2.50.3
@@ -1075,6 +1078,11 @@ packages:
 
   '@supabase/realtime-js@2.11.15':
     resolution: {integrity: sha512-HQKRnwAqdVqJW/P9TjKVK+/ETpW4yQ8tyDPPtRMKOH4Uh3vQD74vmj353CYs8+YwVBKubeUOOEpI9CT8mT4obw==}
+
+  '@supabase/ssr@0.6.1':
+    resolution: {integrity: sha512-QtQgEMvaDzr77Mk3vZ3jWg2/y+D8tExYF7vcJT+wQ8ysuvOeGGjYbZlvj5bHYsj/SpC0bihcisnwPrM4Gp5G4g==}
+    peerDependencies:
+      '@supabase/supabase-js': ^2.43.4
 
   '@supabase/storage-js@2.7.1':
     resolution: {integrity: sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==}
@@ -4673,6 +4681,11 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@supabase/ssr@0.6.1(@supabase/supabase-js@2.50.3)':
+    dependencies:
+      '@supabase/supabase-js': 2.50.3
+      cookie: 1.0.2
 
   '@supabase/storage-js@2.7.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@react-router/serve':
         specifier: ^7.5.3
         version: 7.6.3(react-router@7.6.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)
+      '@supabase/auth-ui-react':
+        specifier: ^0.3.4
+        version: 0.3.6(@supabase/supabase-js@2.50.3)
       '@supabase/ssr':
         specifier: ^0.6.1
         version: 0.6.1(@supabase/supabase-js@2.50.3)
@@ -1063,8 +1066,21 @@ packages:
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
+  '@stitches/core@1.2.8':
+    resolution: {integrity: sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==}
+
   '@supabase/auth-js@2.70.0':
     resolution: {integrity: sha512-BaAK/tOAZFJtzF1sE3gJ2FwTjLf4ky3PSvcvLGEgEmO4BSBkwWKu8l67rLLIBZPDnCyV7Owk2uPyKHa0kj5QGg==}
+
+  '@supabase/auth-ui-react@0.3.6':
+    resolution: {integrity: sha512-xQjLV5VmuZdy0bTLmO2i7vvDzKV5q66W1ZKhgSl867AMuMK47uEiyBCOynce5wjCatwUwk4n6IL+z67dhc+kpw==}
+    peerDependencies:
+      '@supabase/supabase-js': ^2.8.0
+
+  '@supabase/auth-ui-shared@0.1.4':
+    resolution: {integrity: sha512-1kSo4JNLyVsTdHhuHSG0WQ7VotKbeMmoQjzIwbE/heALm9xlDu+0AgTPCx1uae1umOALa1CCQuEdfvz6P02RLA==}
+    peerDependencies:
+      '@supabase/supabase-js': ^2.8.0
 
   '@supabase/functions-js@2.4.5':
     resolution: {integrity: sha512-v5GSqb9zbosquTo6gBwIiq7W9eQ7rE5QazsK/ezNiQXdCbY+bH8D9qEaBIkhVvX4ZRW5rP03gEfw5yw9tiq4EQ==}
@@ -3073,6 +3089,11 @@ packages:
     resolution: {integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==}
     engines: {node: '>= 0.8'}
 
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
   react-dom@19.1.0:
     resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
     peerDependencies:
@@ -3137,6 +3158,10 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
 
   react@19.1.0:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
@@ -3228,6 +3253,9 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
@@ -4655,9 +4683,24 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
+  '@stitches/core@1.2.8': {}
+
   '@supabase/auth-js@2.70.0':
     dependencies:
       '@supabase/node-fetch': 2.6.15
+
+  '@supabase/auth-ui-react@0.3.6(@supabase/supabase-js@2.50.3)':
+    dependencies:
+      '@stitches/core': 1.2.8
+      '@supabase/auth-ui-shared': 0.1.4(@supabase/supabase-js@2.50.3)
+      '@supabase/supabase-js': 2.50.3
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@supabase/auth-ui-shared@0.1.4(@supabase/supabase-js@2.50.3)':
+    dependencies:
+      '@supabase/supabase-js': 2.50.3
 
   '@supabase/functions-js@2.4.5':
     dependencies:
@@ -6777,6 +6820,12 @@ snapshots:
       iconv-lite: 0.6.3
       unpipe: 1.0.0
 
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
   react-dom@19.1.0(react@19.1.0):
     dependencies:
       react: 19.1.0
@@ -6829,6 +6878,10 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.8
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
 
   react@19.1.0: {}
 
@@ -6954,6 +7007,10 @@ snapshots:
       is-regex: 1.2.1
 
   safer-buffer@2.1.2: {}
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
 
   scheduler@0.26.0: {}
 

--- a/supabase/migrations/0001_initial_schema.sql
+++ b/supabase/migrations/0001_initial_schema.sql
@@ -1,0 +1,23 @@
+-- Initial schema for Place Tracker
+CREATE TABLE IF NOT EXISTS categories (
+  id serial PRIMARY KEY,
+  key text NOT NULL,
+  slug text NOT NULL UNIQUE,
+  name text NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS prefectures (
+  id serial PRIMARY KEY,
+  name text NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS places (
+  id serial PRIMARY KEY,
+  prefecture_id integer NOT NULL REFERENCES prefectures(id) ON DELETE CASCADE,
+  category_id integer NOT NULL REFERENCES categories(id) ON DELETE CASCADE,
+  name text NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS visits (
+  place_id integer PRIMARY KEY REFERENCES places(id) ON DELETE CASCADE
+);

--- a/supabase/migrations/0002_functions.sql
+++ b/supabase/migrations/0002_functions.sql
@@ -1,0 +1,42 @@
+-- Functions providing data for the application
+
+CREATE OR REPLACE FUNCTION prefecture_progress(p_category int DEFAULT NULL)
+RETURNS TABLE(id int, name text, visited int, total int)
+LANGUAGE sql STABLE AS $$
+  SELECT pr.id,
+         pr.name,
+         COUNT(v.place_id) AS visited,
+         COUNT(pl.id) AS total
+  FROM prefectures pr
+  LEFT JOIN places pl ON pl.prefecture_id = pr.id
+  LEFT JOIN visits v ON v.place_id = pl.id
+  WHERE p_category IS NULL OR pl.category_id = p_category
+  GROUP BY pr.id, pr.name
+  ORDER BY pr.id;
+$$;
+
+CREATE OR REPLACE FUNCTION places_with_visit(p_prefecture int, p_category int DEFAULT NULL)
+RETURNS TABLE(id int, name text, visited boolean)
+LANGUAGE sql STABLE AS $$
+  SELECT pl.id,
+         pl.name,
+         v.place_id IS NOT NULL AS visited
+  FROM places pl
+  LEFT JOIN visits v ON v.place_id = pl.id
+  WHERE pl.prefecture_id = p_prefecture
+    AND (p_category IS NULL OR pl.category_id = p_category)
+  ORDER BY pl.id;
+$$;
+
+CREATE OR REPLACE FUNCTION places_by_category(p_category int)
+RETURNS TABLE(id int, name text, prefecture_id int, visited boolean)
+LANGUAGE sql STABLE AS $$
+  SELECT pl.id,
+         pl.name,
+         pl.prefecture_id,
+         v.place_id IS NOT NULL AS visited
+  FROM places pl
+  LEFT JOIN visits v ON v.place_id = pl.id
+  WHERE pl.category_id = p_category
+  ORDER BY pl.prefecture_id, pl.id;
+$$;

--- a/supabase/migrations/0003_visits_userid.sql
+++ b/supabase/migrations/0003_visits_userid.sql
@@ -1,0 +1,19 @@
+-- Add user_id to visits table with composite primary key
+alter table if exists visits rename to visits_old;
+
+create table visits (
+  user_id uuid references auth.users(id) on delete cascade,
+  place_id int references places(id) on delete cascade,
+  visited_at timestamptz not null default now(),
+  primary key (user_id, place_id)
+);
+
+insert into visits (user_id, place_id, visited_at)
+select null::uuid, place_id, now() from visits_old;
+
+drop table visits_old;
+
+alter table visits enable row level security;
+create policy "Self-owned visits only" on visits
+  for all
+  using (auth.uid() = user_id);

--- a/supabase/migrations/0004_rpc_userid.sql
+++ b/supabase/migrations/0004_rpc_userid.sql
@@ -1,0 +1,48 @@
+create or replace function prefecture_progress(
+    p_user_id uuid,
+    p_category int default null)
+returns table(id int, name text, visited int, total int)
+language sql stable as $$
+  select pr.id,
+         pr.name,
+         count(v.place_id) filter (where v.user_id = p_user_id) as visited,
+         count(pl.id) as total
+  from prefectures pr
+  left join places pl on pl.prefecture_id = pr.id
+  left join visits v on v.place_id = pl.id
+  where p_category is null or pl.category_id = p_category
+  group by pr.id, pr.name
+  order by pr.id;
+$$;
+
+create or replace function places_with_visit(
+    p_user_id uuid,
+    p_prefecture int,
+    p_category int default null)
+returns table(id int, name text, visited boolean)
+language sql stable as $$
+  select pl.id,
+         pl.name,
+         exists (select 1
+                   from visits v
+                  where v.place_id = pl.id
+                    and v.user_id = p_user_id) as visited
+  from places pl
+  where pl.prefecture_id = p_prefecture
+    and (p_category is null or pl.category_id = p_category)
+  order by pl.id;
+$$;
+
+create or replace function places_by_category(
+    p_user_id uuid,
+    p_category int)
+returns table(id int, name text, prefecture_id int, visited boolean)
+language sql stable as $$
+  select pl.id,
+         pl.name,
+         pl.prefecture_id,
+         exists (select 1 from visits v where v.place_id = pl.id and v.user_id = p_user_id) as visited
+  from places pl
+  where pl.category_id = p_category
+  order by pl.prefecture_id, pl.id;
+$$;


### PR DESCRIPTION
## Summary
- update DB schema: add user_id column and RLS to visits table
- add migrations for user-specific RPC functions
- expose `getUser` helper and Supabase browser client
- update loaders and actions to send userId
- provide React Query hooks for authenticated data

## Testing
- `pnpm run lint`
- `pnpm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6869609f6f8c832597213b9fed4d9878